### PR TITLE
PFDR-124 - Add ingest_status interface

### DIFF
--- a/bin/ingest_status
+++ b/bin/ingest_status
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require "bundler/setup"
+require "chipmunk/status_cli"
+
+Chipmunk::StatusCLI.new(ARGV).run

--- a/lib/chipmunk/status_cli.rb
+++ b/lib/chipmunk/status_cli.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "optparse"
+require "json"
+require "date"
 require "chipmunk/client"
 require "chipmunk"
 
@@ -9,13 +11,13 @@ module Chipmunk
     attr_reader :bags
 
     def initialize(args, client_factory: Client)
-      parse_options(args)
+      validate_options(args)
       @client = client_factory.new
     end
 
     def run
       bags.each do |bag|
-        output_bag_status(bag)
+        puts "#{bag}\t#{status(bag)}"
       end
     end
 
@@ -23,47 +25,197 @@ module Chipmunk
 
     attr_reader :client, :config
 
-    USAGE = "Usage: #{$PROGRAM_NAME} [options] [id_file1] [id_file2...]"
+    USAGE = "Usage: #{$PROGRAM_NAME} [-h] [-c CONFIG] [-i ID]... [FILE]..."
+    SUMMARY = "Get the status for each package id in each file"
+
+    PARAMETER_HELP = <<~HELP
+      When FILE is '-', read standard input. With no FILE or ID, read '-'.
+    HELP
+
+    GENERAL_HELP = <<~HELP
+      Output will be two columns, separated by tabs. Column 1 will
+      contain the bag id; column 2, the status. Here are all the
+      statuses this could return:
+
+          done:       This is valid, stored, and accessible.
+          storing:    This is valid and processed but not yet stored.
+          pending:    This is loaded but not yet processed.
+          failed:     This is loaded, and it failed to process.
+          not_loaded: I know the id, but you haven't loaded the bag yet.
+          not_found:  You haven't told me about this yet.
+
+      Some of these (e.g. 'failed') may have additional relevant
+      messages. If they do, they'll come afterward wrapped in a json
+      string. For example output might look like this:
+
+          $ ingest_status -i id1 -i id2 -i id3 -i id4
+          id1     done
+          id2     done
+          id3     failed: "A helpful error message from the server"
+          id4     pending
+    HELP
+
+    def validate_options(args)
+      parse_options(args)
+    rescue StandardError => error
+      error_out(error)
+    end
+
+    def error_out(error)
+      warn USAGE
+      warn "#{$PROGRAM_NAME}: error: #{error.class} #{error}"
+      exit 1
+    end
 
     def parse_options(args)
       @bags = []
-
-      OptionParser.new do |opts|
-        opts.banner = USAGE
-
-        opts.on("-c CONFIG", "--config", "Configuration file") do |c|
-          Chipmunk.add_config(c)
-        end
-
-        opts.on("-i ID", "--id", "External volume id") do |id|
-          @bags << id
-        end
-      end.parse!(args)
-
-      read_bags_from_argf if bags.empty? || ! args.empty?
-
-      raise ArgumentError, USAGE if bags.empty?
+      option_parser.parse!(args)
+      read_bags_from_argf if bags.empty? || args.size > 0
+      raise ArgumentError.new('expected at least 1 bag id') if bags.empty?
     end
 
     def read_bags_from_argf
-      @bags += ARGF.read
-                   .lines
-                   .map{ |l| l.strip }
-                   .delete_if{ |l| l.empty? }
+      @bags += ARGF.read.lines.map{ |l| l.strip }.delete_if{ |l| l.empty? }
+    rescue Interrupt
+      # If the user ctrl-Cs during this read, it's probably because this
+      # script is hanging, which is probably because the user forgot to
+      # provide any input of any kind. In that case, such hanging is
+      # expected. While not a great UX, we can at least improve it by
+      # not punishing the user with a ruby stack trace.
+      warn USAGE
+      exit 130
     end
 
-    def output_bag_status(bag)
-      response = client.get("/v1/bags/#{bag}")
-
-      if response.has_key? 'stored'
-        if response['stored']
-          puts "#{bag}\tdone"
-        else
-          puts "#{bag}\tnot_stored"
-        end
-      else
-        puts "#{bag}\tnot_found"
+    def option_parser
+      OptionParser.new do |opts|
+        add_topmost_help(opts)
+        add_optional_parameters(opts)
+        add_parameter_help(opts)
       end
+    end
+
+    def add_topmost_help(opts)
+      opts.banner = USAGE
+      opts.separator SUMMARY
+    end
+
+    def add_parameter_help(opts)
+      opts.separator ""
+      opts.separator PARAMETER_HELP
+      opts.separator ""
+      opts.separator GENERAL_HELP
+    end
+
+    def add_optional_parameters(opts)
+      opts.separator ""
+      opts.separator "Optional parameters:"
+
+      add_help_parameter(opts)
+      add_config_parameter(opts)
+      add_id_parameter(opts)
+    end
+
+    def add_help_parameter(opts)
+      opts.on("-h", "--help", "Display this message and exit") do
+        puts opts
+        exit
+      end
+    end
+
+    def add_config_parameter(opts)
+      opts.on("-c CONFIG", "--config", "Configuration file") do |c|
+        Chipmunk.add_config(c)
+      end
+    end
+
+    def add_id_parameter(opts)
+      opts.on("-i ID", "--id", "External volume id") do |id|
+        bags << id
+      end
+    end
+
+    def status(bag)
+      BagStatus.new(client, bag)
+    end
+  end
+
+  private
+
+  class BagStatus
+    def initialize(client, bag)
+      @client = client
+      @bag = bag
+    end
+
+    def to_s
+      status_message
+    end
+
+    private
+
+    attr_reader :client, :bag
+
+    def status_message
+      if bag_is_found?
+        status_of_found_bag
+      else
+        "not_found"
+      end
+    end
+
+    def status_of_found_bag
+      if bag_is_stored?
+        "done"
+      else
+        status_of_known_but_unstored_bag
+      end
+    end
+
+    def status_of_known_but_unstored_bag
+      if bag_has_never_been_loaded?
+        "not_loaded"
+      else
+        status_of_queued_but_unstored_bag
+      end
+    end
+
+    def status_of_queued_but_unstored_bag
+      case latest_queue_object['status']
+      when 'PENDING'
+        "pending"
+      when 'DONE'
+        "storing"
+      when 'FAILED'
+        "failed: #{latest_queue_object['error'].to_json}"
+      else
+        "unrecognized_status: #{latest_queue_object['status'].to_json}"
+      end
+    end
+
+    def bag_is_found?
+      v1_bags_response.has_key? 'stored'
+    end
+
+    def bag_is_stored?
+      v1_bags_response['stored'] == true
+    end
+
+    def bag_has_never_been_loaded?
+      v1_queue_response.empty?
+    end
+
+    def v1_bags_response
+      @v1_bags_response ||= client.get("/v1/bags/#{bag}")
+    end
+
+    def latest_queue_object
+      @latest_queue_object ||= v1_queue_response.reduce do |x, y|
+        DateTime.parse(x["updated_at"]) > DateTime.parse(y["updated_at"]) ? x : y
+      end
+    end
+
+    def v1_queue_response
+      @v1_queue_response ||= client.get("/v1/queue?package=#{bag}")
     end
   end
 end

--- a/lib/chipmunk/status_cli.rb
+++ b/lib/chipmunk/status_cli.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "optparse"
+require "chipmunk/client"
+require "chipmunk"
+
+module Chipmunk
+  class StatusCLI
+    attr_reader :bags
+
+    def initialize(args, client_factory: Client)
+      parse_options(args)
+      @client = client_factory.new
+    end
+
+    def run
+      bags.each do |bag|
+        output_bag_status(bag)
+      end
+    end
+
+    private
+
+    attr_reader :client, :config
+
+    USAGE = "Usage: #{$PROGRAM_NAME} [options] [id_file1] [id_file2...]"
+
+    def parse_options(args)
+      @bags = []
+
+      OptionParser.new do |opts|
+        opts.banner = USAGE
+
+        opts.on("-c CONFIG", "--config", "Configuration file") do |c|
+          Chipmunk.add_config(c)
+        end
+
+        opts.on("-i ID", "--id", "External volume id") do |id|
+          @bags << id
+        end
+      end.parse!(args)
+
+      read_bags_from_argf if bags.empty? || ! args.empty?
+
+      raise ArgumentError, USAGE if bags.empty?
+    end
+
+    def read_bags_from_argf
+      @bags += ARGF.read
+                   .lines
+                   .map{ |l| l.strip }
+                   .delete_if{ |l| l.empty? }
+    end
+
+    def output_bag_status(bag)
+      response = client.get("/v1/bags/#{bag}")
+
+      if response.has_key? 'stored'
+        if response['stored']
+          puts "#{bag}\tdone"
+        else
+          puts "#{bag}\tnot_stored"
+        end
+      else
+        puts "#{bag}\tnot_found"
+      end
+    end
+  end
+end

--- a/spec/chipmunk/status_cli_spec.rb
+++ b/spec/chipmunk/status_cli_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "chipmunk/status_cli"
+
+RSpec.describe Chipmunk::StatusCLI do
+  let(:client_factory) { double(:factory) }
+
+  describe "#initialize" do
+    it "creates a client with the default config" do
+      expect(client_factory).to receive(:new)
+      described_class.new(%w[-i an_id], client_factory: client_factory)
+    end
+
+    it "accepts a -c option with an overriding config" do
+      described_class.new(%w[-c spec/support/fixtures/other_config.yml -i foo])
+      expect(Chipmunk.config.api_key).to eq("overriden_api_key")
+    end
+  end
+
+  describe "#bags" do
+    let(:bags) { described_class.new(args, client_factory: client_factory).bags }
+    let(:client_factory) { double(:client_factory, new: client) }
+    let(:client) { double(:client) }
+    let(:argf) { nil }
+
+    before(:each) do
+      allow(ARGF).to receive(:read).and_return(argf) unless argf.nil?
+    end
+
+    context "when given no stdin and no arguments" do
+      let(:args) { [] }
+
+      it("has no tested behavior but I expect it will hang") { }
+    end
+
+    context "when given `-i id`" do
+      let(:args) { %w[-i id] }
+
+      it { expect(bags).to eq %w[id] }
+
+      context 'with stdin of "another id\n"' do
+        let(:argf) { "another id\n" }
+
+        it { expect(bags).to eq %w[id] }
+      end
+    end
+
+    context "when given `-i id1 -i id2`" do
+      let(:args) { %w[-i id1 -i id2] }
+
+      it { expect(bags).to eq %w[id1 id2] }
+    end
+
+    context "when given ``" do
+      let(:args) { [] }
+      let(:argf) { "id1\nid2\n" }
+
+      it "reads from ARGF line by line" do
+        expect(bags).to eq %w[id1 id2]
+      end
+
+      context "and ARGF contains no ids" do
+        let(:argf) { '' }
+
+        it { expect{ bags }.to raise_error(ArgumentError) }
+      end
+
+      context "and ARGF has ids and a blank line" do
+        let(:argf) { "id 1\nid 2\n\nid 3\n" }
+
+        it "ignores the blank line" do
+          expect(bags).to eq ["id 1", "id 2", "id 3"]
+        end
+      end
+    end
+
+    context "when given `-i cli_id path_to_file`" do
+      let(:args) { %w[-i cli_id path_to_file] }
+      let(:argf) { "file_id" }
+
+      it "reads the `-i` id as well as checking ARGF" do
+        expect(bags).to eq %w[cli_id file_id]
+      end
+    end
+  end
+
+  describe "#run" do
+    let(:run) { described_class.new(args, client_factory: client_factory).run }
+    let(:client_factory) { double(:client_factory, new: client) }
+    let(:client) { double(:client, get: bag_hash) }
+    let(:bag_hash) { {} }
+    let(:bags) { %w[bag1 bag2] }
+
+    let(:args) do
+      [].tap do |a|
+        bags.each do |bag|
+          a << '-i'
+          a << bag
+        end
+      end
+    end
+
+    it "queries /v1/bags/id for each bag" do
+      bags.each do |bag|
+        expect(client).to receive(:get).with("/v1/bags/#{bag}")
+      end
+
+      run
+    end
+
+    context 'when the id 404s' do
+      let(:bags) { ['bad_bag'] }
+      let(:bag_hash) { { 'status' => 404, 'error' => 'Not Found' } }
+
+      it "outputs not_found" do
+        expect{ run }.to output(/bad_bag\tnot_found/).to_stdout
+      end
+    end
+
+    context 'when the bag is stored' do
+      let(:bags) { ['existing_bag'] }
+      let(:bag_hash) { { 'stored' => true } }
+
+      it "outputs done" do
+        expect{ run }.to output(/existing_bag\tdone/).to_stdout
+      end
+    end
+
+    context 'when the bag is not stored' do
+      let(:bags) { ['known_bag'] }
+      let(:bag_hash) { { 'stored' => false } }
+
+      it "outputs not_stored" do
+        expect{ run }.to output(/known_bag\tnot_stored/).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ideally, this would provide information about whether known but
not-stored packages are (a) planned, (b) in process, or (c) failed, but
at the moment the API doesn't allow that.

The `not_stored` status should be replaced as soon as the API is
updated.