### PR TITLE
PFDR-258 - Trim archive flags for rsync

### DIFF
--- a/lib/chipmunk/bag_rsyncer.rb
+++ b/lib/chipmunk/bag_rsyncer.rb
@@ -8,7 +8,7 @@ module Chipmunk
 
     def upload(dest)
       raise "rsync failed" unless
-      system("rsync", "-avzP", "--delete", "#{bag_path}/", dest)
+      system("rsync", "-rtvzP", "--delete", "#{bag_path}/", dest)
     end
 
     private


### PR DESCRIPTION
We should not try to preserve any local user, group, mode, or link
information -- they only cause inconsistency on the repository end.