### PR TITLE
PFDR-255 - Add Bentley Audio as a top level content type

### DIFF
--- a/lib/chipmunk/bagger.rb
+++ b/lib/chipmunk/bagger.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "find"
 require "securerandom"
 require "chipmunk/bag"
 require "chipmunk/check/bag_exists"

--- a/lib/chipmunk/bagger/bentley_audio.rb
+++ b/lib/chipmunk/bagger/bentley_audio.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-require "chipmunk/metadata_error"
 require "chipmunk/bagger"
 
 module Chipmunk
-  class Bagger::AudioLocalMetadata < Bagger
+  class Bagger::BentleyAudio < Bagger
     def initialize(external_id:, bag_path:, src_path: nil, metadata_url:, metadata_type:, metadata_path:)
       super(
-        content_type: "audio",
+        content_type: "bentleyaudio",
         external_id: external_id,
         bag_path: bag_path,
         src_path: src_path

--- a/lib/chipmunk/bagger_cli.rb
+++ b/lib/chipmunk/bagger_cli.rb
@@ -37,6 +37,8 @@ module Chipmunk
       case content_type
       when "audio"
         params[:metadata_path] ? Chipmunk::Bagger::AudioLocalMetadata : Chipmunk::Bagger::Audio
+      when "bentleyaudio"
+        Chipmunk::Bagger::BentleyAudio
       when "digital"
         Chipmunk::Bagger::Digital
       when "video"
@@ -73,6 +75,13 @@ module Chipmunk
       raise ArgumentError, usage if args.size != 3
 
       (@content_type, @external_id, @bag_path) = args
+
+      raise ArgumentError, "All metadata options are required for bentleyaudio. \n\n#{usage}" if bad_bentley_args
+    end
+
+    def bad_bentley_args
+      content_type == "bentleyaudio" &&
+        !([:metadata_type, :metadata_path, :metadata_url].all? {|key| params.key?(key) })
     end
 
   end

--- a/spec/chipmunk/bagger/bentley_audio_spec.rb
+++ b/spec/chipmunk/bagger/bentley_audio_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "chipmunk/bagger/bentley_audio"
+
+RSpec.describe Chipmunk::Bagger::BentleyAudio do
+  let(:ead_url) { "http://quod.lib.umich.edu/b/bhlead/eads/umich-bhl-foo.xml" }
+  let(:external_id) { "12345" }
+  let(:fake_uuid) { "fakeuuid" }
+  let(:good_data_path) { fixture("audio_local_md", "upload", "good", "data") }
+  let(:bag_data) { File.join(@bag_path, "data") }
+  let(:params) do
+    {
+      metadata_url:  ead_url,
+      metadata_type: "EAD",
+      metadata_path: fixture("ead.xml")
+    }
+  end
+
+  context "with fixture data and stubbed Chipmunk::Bag" do
+    include_context "fixture data"
+
+    context "with stubbed Chipmunk::Bag" do
+      include_context "stubbed Chipmunk::Bag"
+
+      context "with good audio data" do
+        let(:fixture_data) { good_data_path }
+
+        before(:each) do
+          allow(bag).to receive(:add_file_by_moving)
+        end
+
+        shared_examples_for "moves files to the data dir" do
+          ["am000001.wav", "pm000001.wav", "mets.xml"].each do |file|
+            it "moves #{file} to the data dir" do
+              expect(bag).to receive(:add_file_by_moving).with(file, File.join(@src_path, file))
+              make_bag("bentleyaudio", **params)
+            end
+          end
+        end
+
+        it "adds the expected metadata tags" do
+          expect(bag).to receive(:write_chipmunk_info).with(
+            "External-Identifier" => external_id,
+            "Chipmunk-Content-Type" => "bentleyaudio",
+            "Bag-ID" => fake_uuid,
+            "Metadata-URL" => ead_url,
+            "Metadata-Type" => "EAD",
+            "Metadata-Tagfile" => "ead.xml"
+          )
+
+          make_bag("bentleyaudio", **params)
+        end
+
+        it "copies the metadata" do
+          expect(bag).to receive(:add_tag_file).with("ead.xml", fixture("ead.xml"))
+          make_bag("bentleyaudio", **params)
+        end
+      end
+    end
+
+    it_behaves_like "a bagger", "bentleyaudio"
+  end
+end

--- a/spec/chipmunk/bagger_cli_spec.rb
+++ b/spec/chipmunk/bagger_cli_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "chipmunk/bagger_cli"
+require "chipmunk/bagger/bentley_audio"
 
 RSpec.describe Chipmunk::BaggerCLI do
   describe "#initialize" do
@@ -48,6 +49,19 @@ RSpec.describe Chipmunk::BaggerCLI do
                                   "--metadata-type", "MARC",
                                   "--metadata-path", "/somewhere/whatever.xml",
                                   "--metadata-url", "http://foo.bar/whatever.xml"]).bagger).to be_a_kind_of(Chipmunk::Bagger::AudioLocalMetadata)
+    end
+
+    it "makes a bentleyaudio bagger with local metadata" do
+      expect(described_class.new(["bentleyaudio", "foo", "-s", "foo", "bar",
+                                  "--metadata-type", "MARC",
+                                  "--metadata-path", "/somewhere/whatever.xml",
+                                  "--metadata-url", "http://foo.bar/whatever.xml"]).bagger).to be_a_kind_of(Chipmunk::Bagger::BentleyAudio)
+    end
+
+    it "requires metadata params for Bentley Audio" do
+      expect {
+        described_class.new(["bentleyaudio", "foo", "-s", "foo", "bar"])
+      }.to raise_error(/require/)
     end
   end
 


### PR DESCRIPTION
This is not an ideal solution, but a practical one. From the
repository's point of view, audio from Bentley is not the same as plain
audio. However, it behaves the same as audio with local metadata. This
commonality and variance give us repetition and subtle difference in the
code, which is subject to refactoring. The best way to do that is not
clear now (how to compose optional/required behavioral elements and
reduce duplication in CLI and bagger test coverage) and I don't want to
block usage on a refactoring expedition that potentially spans three or
four repos.