### PR TITLE
PFDR-255 - support bentley audio content type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     mime-types-data (3.2018.0812)
     mini_portile2 (2.4.0)
     netrc (0.11.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.14.0)
     parser (2.6.2.0)

--- a/lib/chipmunk/bagger/audio.rb
+++ b/lib/chipmunk/bagger/audio.rb
@@ -8,9 +8,9 @@ require "chipmunk/bagger"
 module Chipmunk
   class Bagger::Audio < Bagger
 
-    def initialize(external_id:, bag_path:, src_path: nil)
+    def initialize(content_type:, external_id:, bag_path:, src_path: nil)
       super(
-        content_type: "audio",
+	content_type: content_type,
         external_id: external_id,
         bag_path: bag_path,
         src_path: src_path

--- a/lib/chipmunk/bagger/audio_local_metadata.rb
+++ b/lib/chipmunk/bagger/audio_local_metadata.rb
@@ -6,9 +6,9 @@ require "chipmunk/bagger"
 
 module Chipmunk
   class Bagger::AudioLocalMetadata < Bagger
-    def initialize(external_id:, bag_path:, src_path: nil, metadata_url:, metadata_type:, metadata_path:)
+    def initialize(content_type:, external_id:, bag_path:, src_path: nil, metadata_url:, metadata_type:, metadata_path:)
       super(
-        content_type: "video",
+        content_type: content_type,
         external_id: external_id,
         bag_path: bag_path,
         src_path: src_path
@@ -23,7 +23,7 @@ module Chipmunk
     def make_bag
       move_files_to_bag
       bag.add_tag_file(metadata_target_file, metadata_path)
-      bag.write_chipmunk_info(common_tags.merge(audio_metadata))
+      bag.write_chipmunk_info(common_tags.merge(local_metadata))
       bag.manifest!
     end
 
@@ -31,15 +31,11 @@ module Chipmunk
 
     attr_reader :metadata_url, :metadata_type, :metadata_path
 
-    def common_tags
-      super.merge("Chipmunk-Content-Type" => "audio")
-    end
-
     def metadata_target_file
       "#{@metadata_type.downcase}.xml"
     end
 
-    def audio_metadata
+    def local_metadata
       { "Metadata-URL"     => metadata_url,
         "Metadata-Type"    => metadata_type,
         "Metadata-Tagfile" => metadata_target_file }

--- a/lib/chipmunk/bagger/digital.rb
+++ b/lib/chipmunk/bagger/digital.rb
@@ -6,9 +6,9 @@ require "chipmunk/bag"
 module Chipmunk
   class Bagger::Digital < Bagger
 
-    def initialize(external_id:, bag_path:, src_path: nil)
+    def initialize(content_type:, external_id:, bag_path:, src_path: nil)
       super(
-        content_type: "digital",
+        content_type: content_type,
         external_id: external_id,
         bag_path: bag_path,
         src_path: src_path

--- a/lib/chipmunk/bagger/video.rb
+++ b/lib/chipmunk/bagger/video.rb
@@ -7,9 +7,9 @@ require "chipmunk/check/video"
 module Chipmunk
   class Bagger::Video < Bagger
 
-    def initialize(external_id:, bag_path:, src_path: nil)
+    def initialize(content_type:, external_id:, bag_path:, src_path: nil)
       super(
-        content_type: "video",
+        content_type: content_type,
         external_id: external_id,
         bag_path: bag_path,
         src_path: src_path

--- a/lib/chipmunk/bagger_cli.rb
+++ b/lib/chipmunk/bagger_cli.rb
@@ -27,10 +27,11 @@ module Chipmunk
     attr_reader :content_type, :external_id, :src_path, :bag_path, :params
 
     def make_bagger
-      class_for(content_type).new(external_id: external_id,
-                                   src_path: src_path,
-                                   bag_path: bag_path,
-                                   **params)
+      class_for(content_type).new(content_type: content_type,
+				  external_id: external_id,
+                                  src_path: src_path,
+                                  bag_path: bag_path,
+                                  **params)
     end
 
     def class_for(content_type)

--- a/lib/chipmunk/bagger_cli.rb
+++ b/lib/chipmunk/bagger_cli.rb
@@ -36,7 +36,7 @@ module Chipmunk
 
     def class_for(content_type)
       case content_type
-      when "audio"
+      when /^(bentley)?audio$/
         params[:metadata_path] ? Chipmunk::Bagger::AudioLocalMetadata : Chipmunk::Bagger::Audio
       when "digital"
         Chipmunk::Bagger::Digital

--- a/spec/chipmunk/bagger/audio_local_metadata_spec.rb
+++ b/spec/chipmunk/bagger/audio_local_metadata_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe Chipmunk::Bagger::AudioLocalMetadata do
           make_bag("audio", **params)
         end
 
+	it "can pass through a variant content type" do
+          expect(bag).to receive(:write_chipmunk_info).with(
+            "External-Identifier" => external_id,
+            "Chipmunk-Content-Type" => "variantaudio",
+            "Bag-ID" => fake_uuid,
+            "Metadata-URL" => ead_url,
+            "Metadata-Type" => "EAD",
+            "Metadata-Tagfile" => "ead.xml"
+          )
+
+          make_bag("variantaudio", **params)
+	end
+
         it "copies the metadata" do
           expect(bag).to receive(:add_tag_file).with("ead.xml", fixture("ead.xml"))
           make_bag("audio", **params)

--- a/spec/chipmunk/bagger/audio_local_metadata_spec.rb
+++ b/spec/chipmunk/bagger/audio_local_metadata_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Chipmunk::Bagger::AudioLocalMetadata do
           ["am000001.wav", "pm000001.wav", "mets.xml"].each do |file|
             it "moves #{file} to the data dir" do
               expect(bag).to receive(:add_file_by_moving).with(file, File.join(@src_path, file))
-              make_bag("audio_local_metadata", **params)
+              make_bag("audio", **params)
             end
           end
         end
@@ -49,12 +49,12 @@ RSpec.describe Chipmunk::Bagger::AudioLocalMetadata do
             "Metadata-Tagfile" => "ead.xml"
           )
 
-          make_bag("audio_local_metadata", **params)
+          make_bag("audio", **params)
         end
 
         it "copies the metadata" do
           expect(bag).to receive(:add_tag_file).with("ead.xml", fixture("ead.xml"))
-          make_bag("audio_local_metadata", **params)
+          make_bag("audio", **params)
         end
       end
     end

--- a/spec/chipmunk/bagger/video_spec.rb
+++ b/spec/chipmunk/bagger/video_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Chipmunk::Bagger::Video do
   let(:bag_data) { File.join(@bag_path, "data") }
   let(:bagger) do
     described_class.new(
+      content_type: 'video',
       external_id: external_id,
       src_path: @src_path,
       bag_path: @bag_path

--- a/spec/chipmunk/bagger_cli_spec.rb
+++ b/spec/chipmunk/bagger_cli_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Chipmunk::BaggerCLI do
                                   "--metadata-path", "/somewhere/whatever.xml",
                                   "--metadata-url", "http://foo.bar/whatever.xml"]).bagger).to be_a_kind_of(Chipmunk::Bagger::AudioLocalMetadata)
     end
+
+    it "can make an audio bagger with local metadata using the bentleyaudio content type" do
+      expect(described_class.new(["bentleyaudio", "foo", "-s", "foo", "bar",
+                                  "--metadata-type", "MARC",
+                                  "--metadata-path", "/somewhere/whatever.xml",
+                                  "--metadata-url", "http://foo.bar/whatever.xml"]).bagger).to be_a_kind_of(Chipmunk::Bagger::AudioLocalMetadata)
+    end
   end
 
   describe "#run" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,7 +56,8 @@ def fixture(*path)
 end
 
 def make_bag(content_type, **kwargs)
-  described_class.new(external_id: external_id,
+  described_class.new(content_type: content_type,
+		      external_id: external_id,
                       src_path: @src_path,
                       bag_path: @bag_path, **kwargs).make_bag
 end


### PR DESCRIPTION
Compare to #9.

Basically, this lets the expressed content type in the bag (i.e. the behavior on the server for the bag) vary independently of the class used to make the actual bag (i.e. the behavior from the client's perspective)