### PR TITLE
PFDR-260 - Move back to basic rsync flags

### DIFF
--- a/lib/chipmunk/bag_rsyncer.rb
+++ b/lib/chipmunk/bag_rsyncer.rb
@@ -9,7 +9,7 @@ module Chipmunk
     def upload(dest)
       raise "rsync failed" unless
       system("rsync", "-rtvzP", "--delete", "--no-group",
-             "--perms", "--chmod=ug=rwX,o=", "#{bag_path}/", dest)
+             "--no-perms", "--chmod=ugo=rwX", "#{bag_path}/", dest)
     end
 
     private


### PR DESCRIPTION
The rsync command mentioned in the man page around --no-perms and
--chmod does work as expected, provided that the umask is set 0002 on
the server. I figured out why my setting for that was failing and that
trying to get the setgid bit with --perms was more hassle. It came down
to the pam_umask settings needing to be for sshd, not login.