### PR TITLE
PFDR-269 - Add batch helper scripts

### DIFF
--- a/bin/batch-bag
+++ b/bin/batch-bag
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+if [[ -z "$2" ]]; then
+  echo "Usage: batch-bag <audio|video> <directory> [additional_directory...]"
+  exit 1
+fi
+
+if [[ -n "$CHIPMUNK_HOME" ]]; then
+  if [[ -x "$CHIPMUNK_HOME/bin/makebag" ]]; then
+    MAKEBAG="$CHIPMUNK_HOME/bin/makebag"
+  else
+    echo "If CHIPMUNK_HOME is set, it must point to a chipmunk-client directory with bin/makebag in it."
+    exit 1
+  fi
+elif [[ ! $(which makebag) ]]; then
+  echo "The chipmunk-client bin directory (with makebag and upload) must be on the PATH or you must set CHIPMUNK_HOME to the client directory."
+  exit 1
+else
+  MAKEBAG=$(which makebag)
+fi
+
+if [[ -z "$CHIPMUNK_LOGS" ]]; then
+  echo "You must set CHIPMUNK_LOGS to a directory that is writeable for log files."
+  exit 1
+fi
+
+mkdir -p "$CHIPMUNK_LOGS"
+
+CONTENT_TYPE="$1"
+shift
+
+LOGFILE="$CHIPMUNK_LOGS/batch-$(date +"%Y%m%d%H%M%S").log"
+
+echo "Making batch of bags of type: $CONTENT_TYPE"
+echo "Logging to: $LOGFILE"
+echo "----"
+
+for file in "$@"; do
+  barcode=$(basename $file)
+  directory=$(dirname $file)
+  output=$directory/bagged/$(basename $file)
+  if [[ ! $barcode =~ ^39015.* ]]; then
+    echo "Skipping apparent non-barcode $barcode";
+    continue
+  fi
+  mkdir -p $directory/bagged
+  echo "Bagging $barcode to $output"
+  $MAKEBAG -s $file $CONTENT_TYPE $barcode $output 2>&1 | tee -a $LOGFILE
+done

--- a/bin/batch-upload
+++ b/bin/batch-upload
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if [[ -z "$1" ]]; then
+  echo "Usage: batch-upload <directory> [additional_directory...]"
+  exit 1
+fi
+
+if [[ -n "$CHIPMUNK_HOME" ]]; then
+  if [[ -x "$CHIPMUNK_HOME/bin/upload" ]]; then
+    UPLOAD="$CHIPMUNK_HOME/bin/upload"
+  else
+    echo "If CHIPMUNK_HOME is set, it must point to a chipmunk-client directory with bin/upload in it."
+    exit 1
+  fi
+elif [[ ! $(which upload) ]]; then
+  echo "The chipmunk-client bin directory (with makebag and upload) must be on the PATH or you must set CHIPMUNK_HOME to the client directory."
+  exit 1
+else
+  UPLOAD=$(which upload)
+fi
+
+if [[ -z "$CHIPMUNK_LOGS" ]]; then
+  echo "You must set CHIPMUNK_LOGS to a directory that is writeable for log files."
+  exit 1
+fi
+
+mkdir -p "$CHIPMUNK_LOGS"
+
+LOGFILE="$CHIPMUNK_LOGS/upload-$(date +"%Y%m%d%H%M%S").log"
+
+echo "Uploading batch of bags..."
+echo "Logging to: $LOGFILE"
+echo "----"
+
+$UPLOAD "$@" 2>&1 | tee -a $LOGFILE


### PR DESCRIPTION
These are a couple of utilities to help with bagging and uploading
batches, each with some logging. Putting chipmunk-client/bin on the PATH
and setting CHIPMUNK_LOGS to a writable path for logging is the easiest
way to use these. Alternatively, setting CHIPMUNK_HOME to the client
directory and using an explicit path to batch-bag or batch-upload will
also work.