### PR TITLE
PFDR-268 - Support search URLs alongside Mirlyn URLs

### DIFF
--- a/lib/chipmunk/audio_mets.rb
+++ b/lib/chipmunk/audio_mets.rb
@@ -7,16 +7,18 @@ module Chipmunk
   class AudioMETS
 
     CATALOG_URL_PREFIX = "mirlyn.lib.umich.edu/Record/"
+    SEARCH_URL_PREFIX = "search.lib.umich.edu/catalog/record/"
 
     def initialize(filehandle)
       @doc = Nokogiri::XML(filehandle)
     end
 
     def marcxml_url
-      if (match = mirlyn_url.match(/(#{CATALOG_URL_PREFIX}\d{9})/))
-        "https://#{match[0]}.xml"
+      if (match = mirlyn_url.match(/(#{CATALOG_URL_PREFIX}|#{SEARCH_URL_PREFIX})(\d{9})/))
+        "https://#{CATALOG_URL_PREFIX}#{match[2]}.xml"
       else
-        raise MetadataError, "URL #{mirlyn_url} does not match #{CATALOG_URL_PREFIX}RECORDNUM"
+        raise MetadataError,
+          "URL #{mirlyn_url} does not match #{CATALOG_URL_PREFIX}RECORDNUM or #{SEARCH_URL_PREFIX}RECORDNUM"
       end
     end
 

--- a/spec/chipmunk/audio_mets_spec.rb
+++ b/spec/chipmunk/audio_mets_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe Chipmunk::AudioMETS do
       end
     end
 
+    context "when mets.xml links to a 'search' catalog record" do
+      let(:mets_path) { fixture("audio", "mets-search.xml") }
+      it "resolves to a mirlyn URL for marcxml" do
+        expect(subject).to match(/^https:\/\/mirlyn.lib.umich.edu\/.*\.xml/)
+      end
+    end
+
     context "when MARC link isn't to mirlyn" do
       let(:mets_path) { fixture("audio", "mets-nonmirlyn.xml") }
       it do

--- a/spec/support/fixtures/audio/mets-search.xml
+++ b/spec/support/fixtures/audio/mets-search.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version15/mets.xsd"
+    TYPE="AUDIO RECORDING" ID="mdp.39015087086396" OBJID="39015087086396">
+    <mets:metsHdr CREATEDATE="2017-04-13T09:00:42.125-04:00">
+        <mets:agent ROLE="OTHER">
+            <mets:name>The MediaPreserve</mets:name>
+        </mets:agent>
+    </mets:metsHdr>
+    <mets:dmdSec ID="DMD1">
+        <mets:mdRef LOCTYPE="URL" MDTYPE="MARC"
+          xlink:href="http://search.lib.umich.edu/catalog/record/011500592"/>
+    </mets:dmdSec>
+    <mets:structMap>
+      <div />
+    </mets>
+</mets:mets>


### PR DESCRIPTION
With this change, we accept a MARC URL in the METS pointing to either
mirlyn.lib or search.lib. We extract the barcode and record the MARCXML
URL using the Mirlyn form.