### PR TITLE
PFDR-278 - Support local EAD file for video content type

### DIFF
--- a/bin/batch-ead-bag
+++ b/bin/batch-ead-bag
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "$4" ]]; then
-  echo "Usage: batch-ead-bag <audio> <EAD file> <EAD URL> <directory> [additional_directory...]"
+  echo "Usage: batch-ead-bag <audio|video> <EAD file> <EAD URL> <directory> [additional_directory...]"
   exit 1
 fi
 

--- a/lib/chipmunk/bagger/video_local_metadata.rb
+++ b/lib/chipmunk/bagger/video_local_metadata.rb
@@ -4,6 +4,9 @@ require "chipmunk/bagger"
 require "chipmunk/bagger/with_local_metadata"
 
 module Chipmunk
-  class Bagger::AudioLocalMetadata < Bagger::WithLocalMetadata
+  class Bagger::VideoLocalMetadata < Bagger::WithLocalMetadata
+    def checks
+      super + [Check::Video.new(self)]
+    end
   end
 end

--- a/lib/chipmunk/bagger/with_local_metadata.rb
+++ b/lib/chipmunk/bagger/with_local_metadata.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "find"
+require "chipmunk/metadata_error"
+require "chipmunk/bagger"
+
+module Chipmunk
+  class Bagger::WithLocalMetadata < Bagger
+    def initialize(content_type:, external_id:, bag_path:, src_path: nil, metadata_url:, metadata_type:, metadata_path:)
+      super(
+        content_type: content_type,
+        external_id: external_id,
+        bag_path: bag_path,
+        src_path: src_path
+      )
+      @metadata_url  = metadata_url
+      @metadata_type = metadata_type
+      @metadata_path = metadata_path
+    end
+
+    # Moves data from src_path to bag_path/data, adds metadata, and generates
+    # appropriate manifests
+    def make_bag
+      move_files_to_bag
+      bag.add_tag_file(metadata_target_file, metadata_path)
+      bag.write_chipmunk_info(common_tags.merge(local_metadata))
+      bag.manifest!
+    end
+
+    private
+
+    attr_reader :metadata_url, :metadata_type, :metadata_path
+
+    def metadata_target_file
+      "#{@metadata_type.downcase}.xml"
+    end
+
+    def local_metadata
+      { "Metadata-URL"     => metadata_url,
+        "Metadata-Type"    => metadata_type,
+        "Metadata-Tagfile" => metadata_target_file }
+    end
+
+  end
+end

--- a/lib/chipmunk/bagger_cli.rb
+++ b/lib/chipmunk/bagger_cli.rb
@@ -41,7 +41,7 @@ module Chipmunk
       when "digital"
         Chipmunk::Bagger::Digital
       when "video"
-        Chipmunk::Bagger::Video
+        params[:metadata_path] ? Chipmunk::Bagger::VideoLocalMetadata : Chipmunk::Bagger::Video
       else
         raise ArgumentError, "No processor for content type #{content_type}"
       end

--- a/spec/chipmunk/bagger/video_spec.rb
+++ b/spec/chipmunk/bagger/video_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Chipmunk::Bagger::Video do
         "Chipmunk::Check::BagExists",
         "Chipmunk::Check::Video",
         "Chipmunk::Check::ChipmunkInfo",
+        "Chipmunk::Check::OsMetadata",
       )
     end
   end


### PR DESCRIPTION
There was no special handling for audio, so this is a simple matter of
extracting a base class and adding the one additional check for video.