### PR TITLE
PFDR-281 - Fix up test suite and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.5 as base
+
+RUN gem install bundler
+
+ENV APP_PATH /app
+RUN mkdir -p $APP_PATH
+WORKDIR $APP_PATH
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+ENV RUN_INTEGRATION 1
+
+FROM base as build
+COPY . ./
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  dev:
+    build:
+      context: .
+      target: base
+    command: ["bundle", "exec", "rspec"]
+    volumes:
+      - .:/app

--- a/spec/chipmunk/bagger_spec.rb
+++ b/spec/chipmunk/bagger_spec.rb
@@ -76,14 +76,11 @@ RSpec.describe Chipmunk::Bagger do
       end
 
       it 'raises the error we gave it' do
-        expect{ bagger.run }.to raise_error('injected error')
+        expect { bagger.run }.to output.to_stderr.and raise_error('injected error')
       end
 
       it "warns the user that it couldn't move the files" do
-        expect do
-          bagger.run
-        rescue
-        end.to output(/#{destination}/).to_stderr
+        expect { bagger.run }.to raise_error.and output(/#{destination}/).to_stderr
       end
     end
   end

--- a/spec/chipmunk/cli_spec.rb
+++ b/spec/chipmunk/cli_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe Chipmunk::CLI do
   end
 
   describe "#run" do
+    before(:each) do
+      @stdout = $stdout
+      $stdout = File.open(File::NULL, "w")
+    end
+
+    after(:each) do
+      $stdout = @stdout
+    end
+
     it "calls the uploader with each bag_path" do
       client = double(:client)
       client_factory = double(:client_factory, new: client)

--- a/spec/chipmunk/status_cli_spec.rb
+++ b/spec/chipmunk/status_cli_spec.rb
@@ -152,6 +152,12 @@ RSpec.describe Chipmunk::StatusCLI do
                                     .and_return(bag_hash)
       allow(client).to receive(:get).with(%r{^/v1/queue})
                                     .and_return(queue_array)
+      @stdout = $stdout
+      $stdout = File.open(File::NULL, "w")
+    end
+
+    after(:each) do
+      $stdout = @stdout
     end
 
     it "queries /v1/bags/id for each bag" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,3 +61,11 @@ def make_bag(content_type, **kwargs)
                       src_path: @src_path,
                       bag_path: @bag_path, **kwargs).make_bag
 end
+
+def squelch_stdout(&block)
+  stdout = $stdout
+  $stdout = File.open(File::NULL, "w")
+  block.call
+ensure
+  $stdout = stdout
+end


### PR DESCRIPTION
There were some issues in the test suite after PFDR-275, where we added
intentional output at some stages of the uploader. There was also quite
a bit of extraneous output while running the suite, and this change
silences all of that.

There is now a Dockerfile and docker-compose.yml to make it easy to run
the suite in a container, since there are some Linux dependencies in the
tests. Using docker-compose run dev will run everything.